### PR TITLE
Made StateNotifierBuilder strong

### DIFF
--- a/packages/elementary/lib/src/relations/builder/state_notifier_builder.dart
+++ b/packages/elementary/lib/src/relations/builder/state_notifier_builder.dart
@@ -99,7 +99,7 @@ class EntityStateNotifierBuilder<T> extends StatelessWidget {
           return lBuilder(ctx, entity.data);
         }
 
-        return builder(ctx, entity.data);
+        return builder(ctx, entity.data!);
       },
     );
   }
@@ -116,7 +116,7 @@ typedef LoadingWidgetBuilder<T> = Widget Function(
 /// Builder function for content state.
 /// See also:
 ///   [EntityState] - State of some logical entity.
-typedef DataWidgetBuilder<T> = Widget Function(BuildContext context, T? data);
+typedef DataWidgetBuilder<T> = Widget Function(BuildContext context, T data);
 
 /// Builder function for error state.
 /// See also:

--- a/packages/elementary/test/entity_state_notifier_strong_test.dart
+++ b/packages/elementary/test/entity_state_notifier_strong_test.dart
@@ -1,0 +1,33 @@
+import 'package:elementary/elementary.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  const inCaseOfNull = 'Text in case of null';
+
+  test('nullable argument', () {
+    final nullableNotifier = EntityStateNotifier<String?>();
+
+    EntityStateNotifierBuilder<String?>(
+      listenableEntityState: nullableNotifier,
+      builder: (context, data) {
+        return Text(data ?? inCaseOfNull);
+      },
+    );
+  });
+
+  test('strong argument', () {
+    final nullableNotifier = EntityStateNotifier<String>();
+
+    EntityStateNotifierBuilder<String>(
+      listenableEntityState: nullableNotifier,
+      builder: (context, data) {
+        return Text(data);
+      },
+      errorBuilder: (context, exception, lastDataThatMayBeNull) {
+        return const Text(inCaseOfNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
So, if we have only `builder()` function then we're using `EntityStateNotifierBuilder` in the wrong way.

In any other case all `null` values should go to other builder functions, making `builder()` function able to have strong value.