### PR TITLE
Feat: add method for proxying to onErrorHandle during tests.

### DIFF
--- a/packages/elementary/CHANGELOG.md
+++ b/packages/elementary/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-* 
+### Added
+* method for proxying to onErrorHandle during tests;
 
 ## 3.1.1
 ### Changed

--- a/packages/elementary/lib/src/core.dart
+++ b/packages/elementary/lib/src/core.dart
@@ -427,6 +427,13 @@ abstract class WidgetModel<W extends ElementaryWidget,
   void setupTestElement(BuildContext? testElement) {
     _element = testElement;
   }
+
+  /// Provides a way to call protected [onErrorHandle] in tests.
+  /// MUST be used only for testing purposes.
+  @visibleForTesting
+  void handleTestError(Object error) {
+    onErrorHandle(error);
+  }
 }
 
 /// An element for managing a widget whose display depends on the Widget Model.

--- a/packages/elementary/test/core/widget_model_test.dart
+++ b/packages/elementary/test/core/widget_model_test.dart
@@ -183,6 +183,13 @@ void main() {
 
       expect(wm.context, same(element));
     });
+
+    test('handleTestError should proxy call to onErrorHandle', () {
+      final error = Exception('test error');
+      wm = ElementaryWidgetModelTestKeepError(model)..handleTestError(error);
+
+      expect((wm as ElementaryWidgetModelTestKeepError)._error, same(error));
+    });
   });
 }
 
@@ -205,6 +212,19 @@ class ElementaryWidgetModelTest
     extends WidgetModel<ElementaryWidgetTest, ElementaryModelMock>
     implements IElementaryWidgetModelTest {
   ElementaryWidgetModelTest(ElementaryModelMock model) : super(model);
+}
+
+class ElementaryWidgetModelTestKeepError extends ElementaryWidgetModelTest {
+  late final Object _error;
+
+  ElementaryWidgetModelTestKeepError(super.model);
+
+  @override
+  void onErrorHandle(Object error) {
+    super.onErrorHandle(error);
+
+    _error = error;
+  }
 }
 
 class ElementaryModelMock extends Mock


### PR DESCRIPTION
onErrorHandle is protected, so there is no way to call it (what is expected for normal work).
But for tests, it can be helpful.