### PR TITLE
Feat: Add method handleError for emulating a call of onErrorHandle in WM tests.

### DIFF
--- a/packages/elementary_test/CHANGELOG.md
+++ b/packages/elementary_test/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## Unreleased
-# Added
+### Added
 * Mocked context is mounted by default.
+* Method handleError for emulating a call of onErrorHandle in WM tests.
+### Changed
+* WMTester documentation updated.
 
 ## 2.0.1
 ### Changed

--- a/packages/elementary_test/lib/src/widget_model_test.dart
+++ b/packages/elementary_test/lib/src/widget_model_test.dart
@@ -118,6 +118,9 @@ abstract class WMTester<WM extends WidgetModel, W extends ElementaryWidget> {
   void unmount();
 
   /// Emulates notification WidgetModel about an error from the Model.
+  /// 
+  /// See also:
+  /// [WidgetModel.onErrorHandle];
   void handleError(Object error);
 }
 
@@ -169,6 +172,6 @@ class _WMTestableElement<WM extends WidgetModel, W extends ElementaryWidget>
 
   @override
   void handleError(Object error) {
-    // TODO(mjk): implement after adding the method to main package.
+    _wm.handleTestError(error);
   }
 }

--- a/packages/elementary_test/lib/src/widget_model_test.dart
+++ b/packages/elementary_test/lib/src/widget_model_test.dart
@@ -75,25 +75,50 @@ void testWidgetModel<WM extends WidgetModel, W extends ElementaryWidget>(
 /// Interface for emulating BuildContext behaviour.
 class WMContext extends Mock implements BuildContext {}
 
-/// Interface for control wm stage in test.
+/// Interface for controlling WidgetModel's stage during tests.
+/// Every method in this interface represents possible changes with Widget Model
+/// and allows to emulate this happened.
+///
+/// For additional information check the lifecycle of the [WidgetModel].
 abstract class WMTester<WM extends WidgetModel, W extends ElementaryWidget> {
-  /// Initialize widget model to work.
+  /// Emulates initializing WidgetModel to work.
+  ///
+  /// Represents processes happen with WidgetModel when it is inseted into the
+  /// tree, before the first build of the subtree.
   void init({W? initWidget});
 
-  /// Change the widget used to configure this element.
+  /// Emulates changing a widget instance associated
+  /// with the according Elementary.
   void update(W newWidget);
 
-  /// Called when a dependency of this element changes.
+  /// Emulates changing of dependencies WidgetModel has subscribed
+  /// by BuildContext.
   void didChangeDependencies();
 
-  /// Transition from the "inactive" to the "active" lifecycle state.
+  /// Emulates the transition from the "inactive"
+  /// to the "active" lifecycle state.
+  ///
+  /// In real work happens when the WidgetModel is reinserted into
+  /// the tree after having been removed via [deactivate].
   void activate();
 
-  /// Transition from the "active" to the "inactive" lifecycle state.
+  /// Emulates the transition from the "active"
+  /// to the "inactive" lifecycle state.
+  ///
+  /// In real work happens when the WidgetModel is removed from the tree.
   void deactivate();
 
-  /// Transition from the "inactive" to the "defunct" lifecycle state.
+  /// Emulates the transition from the "inactive"
+  /// to the "defunct" lifecycle state.
+  ///
+  /// In real work happens when the WidgetModel is removed from the
+  /// tree permanently.
+  /// See also:
+  /// [WidgetModel.dispose];
   void unmount();
+
+  /// Emulates notification WidgetModel about an error from the Model.
+  void handleError(Object error);
 }
 
 class _WMTestableElement<WM extends WidgetModel, W extends ElementaryWidget>
@@ -140,5 +165,10 @@ class _WMTestableElement<WM extends WidgetModel, W extends ElementaryWidget>
       ..dispose()
       ..setupTestElement(null)
       ..setupTestWidget(null);
+  }
+
+  @override
+  void handleError(Object error) {
+    // TODO(mjk): implement after adding the method to main package.
   }
 }

--- a/packages/elementary_test/pubspec.yaml
+++ b/packages/elementary_test/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  elementary: ^3.0.0
+  elementary: ^3.1.2
   mocktail: ^1.0.0
   meta: ^1.8.0
 


### PR DESCRIPTION
Related issue.
https://github.com/Elementary-team/flutter-elementary/issues/102